### PR TITLE
Check for blank before search

### DIFF
--- a/searchbox.js
+++ b/searchbox.js
@@ -26,6 +26,10 @@
     },
     
     process: function(terms) {
+      //
+      var blank_check = terms.replace(/\s/g, '');
+      if(blank_check == ''){return false;}
+      //
       var path = $.searchbox.settings.url.split('?'),
         query = [$.searchbox.settings.param, '=', terms].join(''),
         base = path[0], params = path[1], query_string = query


### PR DESCRIPTION
It doesn't look like this is actively maintained, but I like this solution over any others because it does not rely on simply filling in autocomplete and doesn't get in the way.  I saw there was a pull request to specify a number of characters before search, which is a great idea.  However, assuming that its optional, it would make sense to check for blanks before sending the query.

Michael
