### PR TITLE
Allow search to be triggered

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -32,6 +32,10 @@ There are a few places you can hook into the plugin by binding a function to spe
 * <code>before.searchbox</code> - triggered right before the search is performed
 * <code>after.searchbox</code> - triggered right after the search completes
 
+You can also trigger a search like this:
+
+* <code>$('input.search').trigger('search.searchbox')</code> - causes the search to begin even if the search value has not changed
+
 Here's an example of how to make use of them:
 
 <pre><code>$(document).bind('init.searchbox', function() { ... })</code></pre>

--- a/searchbox.js
+++ b/searchbox.js
@@ -54,24 +54,33 @@
     $(document).trigger('init.searchbox')
     $.searchbox.idle()
     
+    var self = this
+
+    var search = function() {
+      var $input = $(self)
+
+      $.searchbox.resetTimer(self.timer)
+
+      self.timer = setTimeout(function() {  
+        $.searchbox.process($input.val())
+      }, $.searchbox.settings.delay)
+     
+      self.previousValue = $input.val()
+    };
+   
     return this.each(function() {
       var $input = $(this)
-      
+
       $input
       .focus()
       .ajaxStart(function() { $.searchbox.start() })
       .ajaxStop(function() { $.searchbox.stop() })
       .keyup(function() {
         if ($input.val() != this.previousValue) {
-          $.searchbox.resetTimer(this.timer)
-
-          this.timer = setTimeout(function() {  
-            $.searchbox.process($input.val())
-          }, $.searchbox.settings.delay)
-        
-          this.previousValue = $input.val()
+          search()
         }
       })
+      .on('search.searchbox', search)
     })
   }
 })(jQuery);


### PR DESCRIPTION
Needed a way to have another action trigger the search so added a 'search.searchbox' event that can trigger the search process even if the search parameters have not changed.
